### PR TITLE
os.rename to shutil.move

### DIFF
--- a/git-raw
+++ b/git-raw
@@ -622,7 +622,7 @@ def add(git, args):
                 perr(err.strerror)
                 return 1
             try:
-                os.rename(path, store_raw)
+                shutil.move(path, store_raw) 
             except OSError as err:
                 perr("error: unable to move '" + path + "' to the store")
                 perr(err.strerror)

--- a/git-raw
+++ b/git-raw
@@ -979,6 +979,9 @@ def fix(git, args):
         if not os.path.lexists(path):
             perr("error: '" + path + "' does not exist")
             return 1
+    if not paths:
+        print("error: git raw fix expects a path") 
+        return 1
 
     # get all broken raw links
     links = git.ls_files_symlinks_in_index(paths)


### PR DESCRIPTION
Using shutil.move() instead of os.rename(). If src and dest are
on different filesystems os.rename will fail. shutil.move
uses os.rename if the files are on the same filesystem, otherwise
it copies src to dst and removes dst.

example: if the data store is on one nfs share and the git repo
on another using os.rename won't work.
